### PR TITLE
fixed teardown issue

### DIFF
--- a/run_braintrust_eval.py
+++ b/run_braintrust_eval.py
@@ -477,7 +477,9 @@ def run_de_bench_task(test_input):
                 return {
                     "status": "infrastructure_only",
                     "message": "Infrastructure inspected, skipping model run",
-                    "resources": test_resources,
+                    "fixtures": fixture_instances,
+                    "test_name": test_name,
+                    "test_resources": test_resources,
                 }
 
             # Register test with fixtures for global cleanup tracking
@@ -1160,6 +1162,18 @@ def run_multi_test_evaluation(
                             if isinstance(output, dict)
                             else {}
                         )
+
+                        # Handle infrastructure_only mode - skip validation
+                        if isinstance(output, dict) and output.get("status") == "infrastructure_only":
+                            print(f"⏭️  Skipping validation for infrastructure-only mode", flush=True)
+                            return {
+                                "name": "validator",
+                                "score": 0.0,
+                                "metadata": {
+                                    "test_steps": [],
+                                    "message": "Infrastructure inspected only - no validation performed",
+                                },
+                            }
 
                         # Get and run the validator
                         validator = get_test_validator(test_name)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Infrastructure-only mode now returns fixtures/test_name/test_resources and the validator skips scoring, preventing validation and enabling proper teardown.
> 
> - **Evaluation Runner (`run_braintrust_eval.py`)**:
>   - **Infrastructure-only mode**:
>     - Return payload now includes `fixtures`, `test_name`, and `test_resources` (removes `resources`).
>     - Unified validator detects `status == "infrastructure_only"` and skips validation, returning a no-op result with message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c5b1ce789dc24455a4eca343120a27a303b9d32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->